### PR TITLE
test: guard against silent image-format regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "scripts": {
     "clean": "rm -rf node_modules",
     "contributors": "(npx git-authors-cli && npx finepack && git add package.json && git commit -m 'build: contributors' --no-verify) || true",
+    "formats:update": "node test/supported-formats.mjs --update",
     "lint": "standard",
     "postrelease": "npm run release:tags && npm run release:github && (ci-publish || npm publish --access=public)",
     "pretest": "npm run lint && node test/supported-formats.mjs",

--- a/test/supported-formats.json
+++ b/test/supported-formats.json
@@ -1,0 +1,12 @@
+[
+  ".avif",
+  ".gif",
+  ".jfif",
+  ".jpg",
+  ".odd",
+  ".png",
+  ".raw",
+  ".svg",
+  ".tiff",
+  ".webp"
+]

--- a/test/supported-formats.mjs
+++ b/test/supported-formats.mjs
@@ -5,6 +5,7 @@ import sharp from 'sharp'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const FIXTURES_PATH = resolve(__dirname, 'fixtures')
+const BASELINE_PATH = resolve(__dirname, 'supported-formats.json')
 
 async function isSharpSupported (buffer) {
   try {
@@ -15,20 +16,53 @@ async function isSharpSupported (buffer) {
   }
 }
 
-const images = await readdir(FIXTURES_PATH)
-const supported = []
-
-for (const image of images) {
-  const filepath = resolve(FIXTURES_PATH, image)
-  const buffer = await readFile(filepath)
-  if (await isSharpSupported(buffer)) {
-    supported.push(extname(image))
+async function detectSupported () {
+  const images = await readdir(FIXTURES_PATH)
+  const supported = []
+  for (const image of images) {
+    const buffer = await readFile(resolve(FIXTURES_PATH, image))
+    if (await isSharpSupported(buffer)) supported.push(extname(image))
   }
+  return [...new Set(supported)].sort()
 }
 
-await writeFile(
-  resolve(__dirname, 'supported-formats.json'),
-  JSON.stringify(supported, null, 2) + '\n'
-)
+const supported = await detectSupported()
 
-console.log('Generated supported-formats.json:', supported.join(', '))
+// `--update` rewrites the committed baseline; do it only when a format change is
+// intentional, so the diff is reviewed in the PR.
+if (process.argv.includes('--update')) {
+  await writeFile(BASELINE_PATH, JSON.stringify(supported, null, 2) + '\n')
+  console.log('Updated supported-formats.json:', supported.join(', '))
+  process.exit(0)
+}
+
+// Otherwise verify against the committed baseline. A dependency bump (sharp or
+// its bundled libvips) that silently drops a decoder must fail here instead of
+// turning those fixtures into skipped tests.
+const baseline = JSON.parse(await readFile(BASELINE_PATH, 'utf8'))
+const regressed = baseline.filter(ext => !supported.includes(ext))
+const added = supported.filter(ext => !baseline.includes(ext))
+
+if (added.length) {
+  console.log(`sharp ${sharp.versions.sharp} now decodes new formats: ${added.join(', ')}`)
+  console.log('Run `npm run formats:update` to adopt them into the baseline.')
+}
+
+if (regressed.length) {
+  console.error(
+    `\nsharp ${sharp.versions.sharp} (libvips ${sharp.versions.vips}) regressed: ` +
+      `${regressed.join(', ')} can no longer be decoded.`
+  )
+  console.error(
+    'If this loss is intentional, run `npm run formats:update` to update the baseline.'
+  )
+  // The baseline reflects the platform splashy ships from (the CI runner). sharp
+  // bundles a different libvips build per platform, so a local machine may decode
+  // fewer formats — only hard-fail in CI to avoid false negatives on dev machines.
+  if (process.env.CI) process.exit(1)
+  console.error('(not failing locally: set CI=1 to enforce the baseline)')
+} else {
+  console.log(
+    `sharp ${sharp.versions.sharp} (libvips ${sharp.versions.vips}) decodes all ${baseline.length} baseline formats.`
+  )
+}


### PR DESCRIPTION
## Problem

The format-coverage test couldn't catch a sharp regression because it was **self-referential**:

- `test/supported-formats.json` was **regenerated from the installed sharp** on every `pretest` run and **never committed**.
- `test/index.js` then `test.skip`-ped any format missing from that freshly-generated list.

So when `sharp@0.35` dropped decoding for BMP and 15 other formats (its bundled libvips no longer ships those loaders), those tests **silently became skips** and CI stayed green. The PR diff showed nothing. (This surfaced downstream as a `get-media-meta` failure in `microlink/api`.)

## Fix

- **Commit `test/supported-formats.json`** as a baseline contract — the formats actually decodable on CI (`docker-vips`, libvips 8.17.x): `avif gif jfif jpg odd png raw svg tiff webp`.
- **Turn `pretest` into a regression guard** (`test/supported-formats.mjs`): probes the installed sharp and **fails in CI** if a baseline format can no longer be decoded, instead of skipping it. It only **warns locally**, since sharp ships a different libvips build per platform (a dev machine may decode fewer/more than CI).
- Add **`npm run formats:update`** for intentional baseline changes, so adopting/dropping a format is a reviewed diff.

Sharp is intentionally left at the latest (`0.35.1`): the dropped formats need a libvips built with those loaders, which the CI image doesn't provide — so pinning sharp wouldn't restore them here. This PR is the prevention mechanism; expanding the decodable set is a separate libvips/image change.

## How this would have caught the regression

With the baseline committed, a future sharp/libvips bump that drops a baseline format hits the guard in `pretest` and turns CI **red**, listing the lost formats — instead of silently converting them to skips.

## Verified

- CI image (`docker-vips`, libvips 8.17.x) + sharp 0.35.1 → guard reports `decodes all 10 baseline formats`, exit 0 ✅
- regression + `CI=1` → guard exits 1 with the regressed list ✅
- local (different libvips build) → warns, exit 0 ✅
- `standard` lint passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)